### PR TITLE
fix missing constants by requiring 'guard/compat/plugin'

### DIFF
--- a/lib/guard/jammit.rb
+++ b/lib/guard/jammit.rb
@@ -2,6 +2,7 @@
 # It will either be required or a stub will be supplied by the test class
 
 require 'jammit'
+require 'guard/compat/plugin'
 
 module Guard
   # The Jammit Guard that gets notifications about the following


### PR DESCRIPTION
Hey folks,

We're the maintainers of jammit (and DocumentCloud).  We've been using `guard-jammit` for a while and just noticed after upgrading to the newest version of guard that the current `guard-jammit` gem is pretty far out of date.

We were wondering whether @reefdog & I could help with the maintenance and release process of `guard-jammit`, especially as we're getting back to maintaining jammit in an active fashion.

we dig guard, so thanks for creating it :)
